### PR TITLE
Adding a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:latest as certificates
+RUN apk update && apk add --no-cache ca-certificates && update-ca-certificates
+
+FROM golang:1.12 as builder
+WORKDIR /build
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /app/plex_exporter main.go
+
+FROM scratch
+COPY --from=certificates /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /app/plex_exporter /app/plex_exporter
+
+WORKDIR /app
+ENTRYPOINT [ "/app/plex_exporter" ]


### PR DESCRIPTION
Multi stage dockerfile, to produce a small image with just the compiled binary and some root certificates. Users will need to mount their `config.json` file, but otherwise it's pretty standard.

I've pushed an image here as well: https://hub.docker.com/r/benclapp/plex_exporter