### PR TITLE
Refactor metrics collection

### DIFF
--- a/collector/plex_collector.go
+++ b/collector/plex_collector.go
@@ -55,7 +55,11 @@ func (c *PlexCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (c *PlexCollector) Collect(ch chan<- prometheus.Metric) {
-	v := c.client.GetServerMetrics()
+	v, err := c.client.GetServerMetrics()
+	if err != nil {
+		c.Logger.Errorf("Could not retrieve server metrics: %s", err)
+		return
+	}
 
 	c.Logger.Trace(v)
 	c.serverInfo.WithLabelValues(v.Version, v.Platform).Set(1)

--- a/collector/plex_collector.go
+++ b/collector/plex_collector.go
@@ -27,7 +27,7 @@ func NewPlexCollector(c *plex.PlexClient, l *log.Entry) *PlexCollector {
 				Name:      "info",
 				Help:      "Information about Plex server",
 			},
-			[]string{"server_name", "server_id", "version", "platform"},
+			[]string{"version", "platform"},
 		),
 		sessionsMetric: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
@@ -36,7 +36,7 @@ func NewPlexCollector(c *plex.PlexClient, l *log.Entry) *PlexCollector {
 				Name:      "active_count",
 				Help:      "Number of active Plex sessions",
 			},
-			[]string{"server_name", "server_id"},
+			[]string{},
 		),
 		libraryMetric: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
@@ -45,7 +45,7 @@ func NewPlexCollector(c *plex.PlexClient, l *log.Entry) *PlexCollector {
 				Name:      "section_size_count",
 				Help:      "Number of items in a library section",
 			},
-			[]string{"server_name", "server_id", "name", "type"},
+			[]string{"name", "type"},
 		),
 	}
 }
@@ -58,11 +58,11 @@ func (c *PlexCollector) Collect(ch chan<- prometheus.Metric) {
 	v := c.client.GetServerMetrics()
 
 	c.Logger.Trace(v)
-	c.serverInfo.WithLabelValues(v.Name, v.ID, v.Version, v.Platform).Set(1)
-	c.sessionsMetric.WithLabelValues(v.Name, v.ID).Set(float64(v.ActiveSessions))
+	c.serverInfo.WithLabelValues(v.Version, v.Platform).Set(1)
+	c.sessionsMetric.WithLabelValues().Set(float64(v.ActiveSessions))
 
 	for _, l := range v.Libraries {
-		c.libraryMetric.WithLabelValues(v.Name, v.ID, l.Name, l.Type).Set(float64(l.Size))
+		c.libraryMetric.WithLabelValues(l.Name, l.Type).Set(float64(l.Size))
 	}
 
 	c.serverInfo.Collect(ch)

--- a/collector/plex_collector.go
+++ b/collector/plex_collector.go
@@ -51,7 +51,9 @@ func NewPlexCollector(c *plex.PlexClient, l *log.Entry) *PlexCollector {
 }
 
 func (c *PlexCollector) Describe(ch chan<- *prometheus.Desc) {
-	prometheus.DescribeByCollect(c, ch)
+	c.serverInfo.Describe(ch)
+	c.sessionsMetric.Describe(ch)
+	c.libraryMetric.Describe(ch)
 }
 
 func (c *PlexCollector) Collect(ch chan<- prometheus.Metric) {

--- a/collector/plex_collector.go
+++ b/collector/plex_collector.go
@@ -55,16 +55,14 @@ func (c *PlexCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (c *PlexCollector) Collect(ch chan<- prometheus.Metric) {
-	serverMetrics := c.client.GetServerMetrics()
+	v := c.client.GetServerMetrics()
 
-	for _, v := range serverMetrics {
-		c.Logger.Trace(v)
-		c.serverInfo.WithLabelValues(v.Name, v.ID, v.Version, v.Platform).Set(1)
-		c.sessionsMetric.WithLabelValues(v.Name, v.ID).Set(float64(v.ActiveSessions))
+	c.Logger.Trace(v)
+	c.serverInfo.WithLabelValues(v.Name, v.ID, v.Version, v.Platform).Set(1)
+	c.sessionsMetric.WithLabelValues(v.Name, v.ID).Set(float64(v.ActiveSessions))
 
-		for _, l := range v.Libraries {
-			c.libraryMetric.WithLabelValues(v.Name, v.ID, l.Name, l.Type).Set(float64(l.Size))
-		}
+	for _, l := range v.Libraries {
+		c.libraryMetric.WithLabelValues(v.Name, v.ID, l.Name, l.Type).Set(float64(l.Size))
 	}
 
 	c.serverInfo.Collect(ch)

--- a/main.go
+++ b/main.go
@@ -69,12 +69,12 @@ func Run(c *cli.Context) error {
 		}
 	}
 
-	// if conf.AutoDiscover {
-	// 	discoveryList, err := plex.DiscoverServers(h)
-	// 	if err == nil {
-	// 		serverList = append(serverList, discoveryList...)
-	// 	}
-	// }
+	if conf.AutoDiscover {
+		discoveryList, err := plex.DiscoverServers(conf.Token)
+		if err == nil {
+			serverList = append(serverList, discoveryList...)
+		}
+	}
 
 	l.Infof("Found %d working servers", len(serverList))
 

--- a/plex/client.go
+++ b/plex/client.go
@@ -5,7 +5,6 @@ import (
 	"runtime"
 	"strconv"
 
-	"github.com/arnarg/plex_exporter/config"
 	v "github.com/arnarg/plex_exporter/version"
 	log "github.com/sirupsen/logrus"
 )
@@ -22,95 +21,65 @@ var headers = map[string]string{
 }
 
 type PlexClient struct {
-	Logger  *log.Entry
-	Servers []*Server
-	headers map[string]string
+	Logger *log.Entry
+	server *Server
 }
 
-func NewPlexClient(c *config.PlexConfig, l *log.Entry) (*PlexClient, error) {
-	var serverList []*Server
-
-	h := headers
-	h["X-Plex-Token"] = c.Token
-
-	for _, serverConf := range c.Servers {
-		plexServer, err := NewServer(serverConf)
-		if err != nil {
-			l.Errorf("Could not add server %s: %s", serverConf.BaseURL, err)
-		} else {
-			serverList = append(serverList, plexServer)
-		}
-	}
-
-	if c.AutoDiscover {
-		discoveryList, err := discoverServers(h)
-		if err == nil {
-			serverList = append(serverList, discoveryList...)
-		}
-	}
-
-	l.Infof("Found %d working servers", len(serverList))
-
+func NewPlexClient(s *Server, l *log.Entry) (*PlexClient, error) {
 	return &PlexClient{
-		Logger:  l,
-		Servers: serverList,
-		headers: h,
+		Logger: l,
+		server: s,
 	}, nil
 }
 
 // GetServerMetrics fetches all metrics for each server and returns them in a map
 // with the servers' names as keys.
-func (c *PlexClient) GetServerMetrics() map[string]ServerMetric {
-	serverMap := map[string]ServerMetric{}
+func (c *PlexClient) GetServerMetrics() ServerMetric {
+	logger := c.Logger.WithFields(log.Fields{"server": c.server.Name})
 
-	for _, server := range c.Servers {
-		logger := c.Logger.WithFields(log.Fields{"server": server.Name})
-
-		serverMetric := ServerMetric{
-			ID:       server.ID,
-			Name:     server.Name,
-			Version:  server.Version,
-			Platform: server.Platform,
-		}
-
-		// Get active sessions
-		activeSessions, err := server.GetSessionCount()
-		if err != nil {
-			logger.Errorf("Could not get metrics for server \"%s\"", server.Name)
-			logger.Debugf("Could not get session count: %s", err)
-			continue
-		}
-		serverMetric.ActiveSessions = activeSessions
-
-		// Get library metrics
-		library, err := server.GetLibrary()
-		if err != nil {
-			logger.Errorf("Could not get metrics for server \"%s\"", server.Name)
-			logger.Debugf("Could not get library: %s", err)
-			continue
-		}
-
-		for _, section := range library.Sections {
-			id, err := strconv.Atoi(section.ID)
-			if err != nil {
-				logger.Debugf("Could not convert sections ID to int. (%s)", section.ID)
-			}
-			size, err := server.GetSectionSize(id)
-			if err != nil {
-				logger.Debugf("Could not get section size for \"%s\": %s", section.Name, err)
-				continue
-			}
-			libraryMetric := LibraryMetric{
-				Name: section.Name,
-				Type: section.Type,
-				Size: size,
-			}
-
-			serverMetric.Libraries = append(serverMetric.Libraries, libraryMetric)
-		}
-
-		serverMap[server.Name] = serverMetric
+	serverMetric := ServerMetric{
+		ID:       c.server.ID,
+		Name:     c.server.Name,
+		Version:  c.server.Version,
+		Platform: c.server.Platform,
 	}
 
-	return serverMap
+	// Get active sessions
+	activeSessions, err := c.server.GetSessionCount()
+	if err != nil {
+		logger.Errorf("Could not get metrics")
+		logger.Debugf("Could not get session count: %s", err)
+		// TODO fix
+		return serverMetric
+	}
+	serverMetric.ActiveSessions = activeSessions
+
+	// Get library metrics
+	library, err := c.server.GetLibrary()
+	if err != nil {
+		logger.Errorf("Could not get metrics")
+		logger.Debugf("Could not get library: %s", err)
+		return serverMetric
+	}
+
+	for _, section := range library.Sections {
+		id, err := strconv.Atoi(section.ID)
+		if err != nil {
+			logger.Debugf("Could not convert sections ID to int. (%s)", section.ID)
+		}
+		size, err := c.server.GetSectionSize(id)
+		if err != nil {
+			logger.Debugf("Could not get section size for \"%s\": %s", section.Name, err)
+			return serverMetric
+		}
+		libraryMetric := LibraryMetric{
+			Name: section.Name,
+			Type: section.Type,
+			Size: size,
+		}
+
+		serverMetric.Libraries = append(serverMetric.Libraries, libraryMetric)
+	}
+
+	return serverMetric
 }

--- a/plex/client.go
+++ b/plex/client.go
@@ -38,8 +38,6 @@ func (c *PlexClient) GetServerMetrics() ServerMetric {
 	logger := c.Logger.WithFields(log.Fields{"server": c.server.Name})
 
 	serverMetric := ServerMetric{
-		ID:       c.server.ID,
-		Name:     c.server.Name,
 		Version:  c.server.Version,
 		Platform: c.server.Platform,
 	}

--- a/plex/client.go
+++ b/plex/client.go
@@ -20,7 +20,7 @@ func NewPlexClient(s *Server, l *log.Entry) (*PlexClient, error) {
 
 // GetServerMetrics fetches all metrics for each server and returns them in a map
 // with the servers' names as keys.
-func (c *PlexClient) GetServerMetrics() ServerMetric {
+func (c *PlexClient) GetServerMetrics() (ServerMetric, error) {
 	logger := c.Logger.WithFields(log.Fields{"server": c.server.Name})
 
 	serverMetric := ServerMetric{
@@ -31,19 +31,16 @@ func (c *PlexClient) GetServerMetrics() ServerMetric {
 	// Get active sessions
 	activeSessions, err := c.server.GetSessionCount()
 	if err != nil {
-		logger.Errorf("Could not get metrics")
 		logger.Debugf("Could not get session count: %s", err)
-		// TODO fix
-		return serverMetric
+		return serverMetric, err
 	}
 	serverMetric.ActiveSessions = activeSessions
 
 	// Get library metrics
 	library, err := c.server.GetLibrary()
 	if err != nil {
-		logger.Errorf("Could not get metrics")
 		logger.Debugf("Could not get library: %s", err)
-		return serverMetric
+		return serverMetric, err
 	}
 
 	for _, section := range library.Sections {
@@ -54,7 +51,7 @@ func (c *PlexClient) GetServerMetrics() ServerMetric {
 		size, err := c.server.GetSectionSize(id)
 		if err != nil {
 			logger.Debugf("Could not get section size for \"%s\": %s", section.Name, err)
-			return serverMetric
+			return serverMetric, err
 		}
 		libraryMetric := LibraryMetric{
 			Name: section.Name,
@@ -65,5 +62,5 @@ func (c *PlexClient) GetServerMetrics() ServerMetric {
 		serverMetric.Libraries = append(serverMetric.Libraries, libraryMetric)
 	}
 
-	return serverMetric
+	return serverMetric, nil
 }

--- a/plex/client.go
+++ b/plex/client.go
@@ -1,24 +1,10 @@
 package plex
 
 import (
-	"fmt"
-	"runtime"
 	"strconv"
 
-	v "github.com/arnarg/plex_exporter/version"
 	log "github.com/sirupsen/logrus"
 )
-
-var headers = map[string]string{
-	"User-Agent":               fmt.Sprintf("plex_exporter/%s", v.Version),
-	"Accept":                   "application/json",
-	"X-Plex-Platform":          runtime.GOOS,
-	"X-Plex-Version":           v.Version,
-	"X-Plex-Client-Identifier": fmt.Sprintf("plex-exporter-v%s", v.Version),
-	"X-Plex-Device-Name":       "Plex Exporter",
-	"X-Plex-Product":           "Plex Exporter",
-	"X-Plex-Device":            runtime.GOOS,
-}
 
 type PlexClient struct {
 	Logger *log.Entry

--- a/plex/plextv.go
+++ b/plex/plextv.go
@@ -25,7 +25,7 @@ type Pin struct {
 	AuthToken string    `json:"auth_token"`
 }
 
-func discoverServers(h map[string]string) ([]*Server, error) {
+func DiscoverServers(h map[string]string) ([]*Server, error) {
 	httpClient := &http.Client{Timeout: time.Second * 10}
 	// This endpoint only supports XML.
 	// I want to specify the "Accept: application/xml" header

--- a/plex/plextv.go
+++ b/plex/plextv.go
@@ -25,14 +25,16 @@ type Pin struct {
 	AuthToken string    `json:"auth_token"`
 }
 
-func DiscoverServers(h map[string]string) ([]*Server, error) {
+func DiscoverServers(token string) ([]*Server, error) {
+	h := headers
 	httpClient := &http.Client{Timeout: time.Second * 10}
 	// This endpoint only supports XML.
 	// I want to specify the "Accept: application/xml" header
 	// to make sure that if the endpoint does support JSON in
 	// the future it won't break the application.
 	eh := map[string]string{
-		"Accept": "application/xml",
+		"Accept":       "application/xml",
+		"X-Plex-Token": token,
 	}
 	mergo.Merge(&eh, h)
 

--- a/plex/server_metric.go
+++ b/plex/server_metric.go
@@ -1,8 +1,6 @@
 package plex
 
 type ServerMetric struct {
-	ID             string
-	Name           string
 	Version        string
 	Platform       string
 	ActiveSessions int

--- a/plex/util.go
+++ b/plex/util.go
@@ -1,8 +1,12 @@
 package plex
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
+	"runtime"
+
+	v "github.com/arnarg/plex_exporter/version"
 )
 
 // SendRequest sends a HTTP request according to provided method and url.
@@ -39,4 +43,15 @@ func createRequest(m, u string, h map[string]string) (*http.Request, error) {
 	}
 
 	return req, nil
+}
+
+var headers = map[string]string{
+	"User-Agent":               fmt.Sprintf("plex_exporter/%s", v.Version),
+	"Accept":                   "application/json",
+	"X-Plex-Platform":          runtime.GOOS,
+	"X-Plex-Version":           v.Version,
+	"X-Plex-Client-Identifier": fmt.Sprintf("plex-exporter-v%s", v.Version),
+	"X-Plex-Device-Name":       "Plex Exporter",
+	"X-Plex-Product":           "Plex Exporter",
+	"X-Plex-Device":            runtime.GOOS,
 }


### PR DESCRIPTION
Sorry for the totally unsolicited PR; I went down this road mostly for exploratory purposes and figured it's in good shape to actually submit. Feel free to reject it, but in general, I think this refactor will make it easier to add richer, multidimensional metrics to the exporter.

### Goals

I initially set out to add more detailed statistics about in-progress sessions. Things like client platform information, stream bitrate, transcoder decisions and information, whether or not the client is local or remote, etc. I wanted to implement these as vector metrics that were labeled according to their parameters, so imagine something like:

```
plex_sessions_total{local="true",platform="iOS",state="playing",delivery="directplay"} 0
plex_sessions_total{local="true",platform="iOS",state="playing",delivery="transcode"} 0
...
```

It's possible I'm just unfamiliar with the Go Prometheus API, but with the `MustNewConstMetric` approach, I found it very difficult to deal with label vectors as opposed to using `CounterVec` or `GaugeVec`.

### What I Changed

- The client API is now only aware of its associated server, not all servers.
- One client instance is created for each Plex server, and one collector is associated with it.
- Server ID and name labels are added when the associated collector is registered so that the metric label definitions in the collector don't actually need to include the `server_id` and `server_name` labels

### What I Tested

- Configuration from YAML file with multiple servers
- Autodiscovery
- Killed servers after starting to verify that collector errors don't crash the process