### PR TITLE
Throw error and exit when unable to find a plex server

### DIFF
--- a/plex/client.go
+++ b/plex/client.go
@@ -49,6 +49,10 @@ func NewPlexClient(c *config.PlexConfig, l *log.Entry) (*PlexClient, error) {
 		}
 	}
 
+	if len(serverList) < 1 {
+		return nil, fmt.Errorf("Could not find a plex server")
+	}
+
 	l.Infof("Found %d working servers", len(serverList))
 
 	return &PlexClient{


### PR DESCRIPTION
If the plex exporter is unable to find a plex server, it continues to run, doing nothing. This situation may happen if Plex is started after the plex exporter or if Plex is down for a while then restarted. 

I found an easy solution is to have the plex exporter exit when all Plex servers are unavailable and let the supervisor, such as systemd, restart the process to allow it to retry again. 

Maybe a better solution would be to have the plex export periodically retry connecting to plex servers, but this solution is simple and works.